### PR TITLE
ignore config folder for codecov

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
         <artifactId>jacoco-maven-plugin</artifactId>
         <configuration>
           <excludes>
-            <exclude>**/config/*</exclude>
+            <exclude>**/config/**</exclude>
             <exclude>**/*Retropolis.*</exclude>
           </excludes>
         </configuration>


### PR DESCRIPTION
The package restructure we did on the config folder did not match with the execution we had on the jacoco, so I fixed that